### PR TITLE
[fix] dao 메소드 이름 변경, 날짜 컬럼 문제해결, 테스트코드 수정

### DIFF
--- a/app/src/androidTest/java/com/preonboarding/locationhistory/local/dao/HistoryDaoTest.kt
+++ b/app/src/androidTest/java/com/preonboarding/locationhistory/local/dao/HistoryDaoTest.kt
@@ -6,13 +6,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.preonboarding.locationhistory.local.database.AppDatabase
-import com.preonboarding.locationhistory.local.entity.History
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -37,20 +35,17 @@ class HistoryDaoTest {
 
     @Test
     fun historyDaoTest() {
-        val history = History(latitude = 3.3, longitude = 3.3)
-        appDatabase.historyDao().insertHistory(latitude = 3.3, longitude = 3.3)
+        val latitude = 3.3
+        val longitude = 4.4
+        val createdAt = "2022-09-22" //today's yyyy-mm-dd
+        appDatabase.historyDao().insertHistory(latitude, longitude)
 
-//        var historyByDistance = appDatabase.historyDao().findDistinctByDistance(distance = 0.2)[0]
-//        Log.d("historyByDistance", historyByDistance.toString())
-//        assertThat(history.latitude, equalTo(historyByDistance.latitude))
+        var findAll = appDatabase.historyDao().findAll()
+        Log.d("findAll", findAll.toString())
+        assertThat(latitude, equalTo(findAll[0].latitude))
 
-//        var historyByDistanceAndCreatedAt = appDatabase.historyDao()
-//            .findHistoryByDistanceAndCreatedAt(
-//                distance = 0.2,
-//                createdAt = LocalDate.now().toString()
-//            )[0]
-//        Log.d("now", LocalDate.now().toString())
-//        Log.d("historyByDistanceAndCreatedAt", historyByDistanceAndCreatedAt.toString())
-//        assertThat(history.latitude, equalTo(historyByDistanceAndCreatedAt.latitude))
+        var findByCreatedAt = appDatabase.historyDao().findByCreatedAt(createdAt)
+        Log.d("findByCreatedAt", findByCreatedAt.toString())
+        assertThat(latitude, equalTo(findByCreatedAt[0].latitude))
     }
 }

--- a/app/src/main/java/com/preonboarding/locationhistory/local/dao/HistoryDao.kt
+++ b/app/src/main/java/com/preonboarding/locationhistory/local/dao/HistoryDao.kt
@@ -1,6 +1,5 @@
 package com.preonboarding.locationhistory.local.dao
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Query
 import com.preonboarding.locationhistory.local.entity.History
@@ -12,13 +11,12 @@ interface HistoryDao {
 
 
     @Query("SELECT DISTINCT latitude, longitude FROM history")
-    fun findDistinctByDistance(): List<History>
+    fun findAll(): List<History>
 
     /*
     * createdAt 형태가 0000-00-00 00:00:00인데 날짜비교 할때 시간 빼고 0000-00-00만 비교해야하기 때문에
     * String으로 사용하면 비교가 어려울 것 같고 @TypeConverter 이용해서 Long으로 써야할 것 같죠..?
     */
-
-    @Query("SELECT * FROM history WHERE created_at = :createdAt")
-    fun findByDistanceAndCreatedAt(createdAt: String): List<History>
+    @Query("SELECT * FROM history WHERE date(created_at) = :createdAt")
+    fun findByCreatedAt(createdAt: String): List<History>
 }

--- a/app/src/main/java/com/preonboarding/locationhistory/local/dao/HistoryDao.kt
+++ b/app/src/main/java/com/preonboarding/locationhistory/local/dao/HistoryDao.kt
@@ -9,14 +9,9 @@ interface HistoryDao {
     @Query("INSERT INTO history (latitude, longitude) VALUES(:latitude, :longitude)")
     fun insertHistory(latitude: Double, longitude: Double)
 
-
     @Query("SELECT DISTINCT latitude, longitude FROM history")
     fun findAll(): List<History>
 
-    /*
-    * createdAt 형태가 0000-00-00 00:00:00인데 날짜비교 할때 시간 빼고 0000-00-00만 비교해야하기 때문에
-    * String으로 사용하면 비교가 어려울 것 같고 @TypeConverter 이용해서 Long으로 써야할 것 같죠..?
-    */
     @Query("SELECT * FROM history WHERE date(created_at) = :createdAt")
     fun findByCreatedAt(createdAt: String): List<History>
 }

--- a/app/src/main/java/com/preonboarding/locationhistory/local/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/preonboarding/locationhistory/local/repository/HistoryRepositoryImpl.kt
@@ -12,10 +12,10 @@ class HistoryRepositoryImpl(
     }
 
     override fun findDistinctByDistance(): List<History> {
-        return historyDao.findDistinctByDistance()
+        return historyDao.findAll()
     }
 
     override fun findByDistanceAndCreatedAt(createdAt: String): List<History> {
-        return historyDao.findByDistanceAndCreatedAt(createdAt)
+        return historyDao.findByCreatedAt(createdAt)
     }
 }


### PR DESCRIPTION
## 수정사항
- dao 메소드 이름을 변경된 쿼리문에 맞춰서 수정했습니다
- 날짜 컬럼 문제 해결했습니다. 해결하고 나니 간단한건데 너무 삽질했네요ㅎ 
- findByCreatedAt 메소드에 함수인자 넘겨줄 때 String 타입의 0000-00-00 형태로 사용하시면 됩니다.
- 테스트코드도 현 dao에 맞춰서 수정했습니다.